### PR TITLE
fix: correctly apply priority tags on SSR

### DIFF
--- a/src/gatsby-ssr.tsx
+++ b/src/gatsby-ssr.tsx
@@ -15,6 +15,7 @@ export const onRenderBody: GatsbySSR['onRenderBody'] = ({
     setHeadComponents([
       helmet.base.toComponent(),
       helmet.title.toComponent(),
+      helmet.priority.toComponent(),
       helmet.meta.toComponent(),
       helmet.link.toComponent(),
       helmet.style.toComponent(),


### PR DESCRIPTION
Currently, the priority tags are not applied to the page during SSR time, leading to the HTML files not including any tags that are marked as priority.

This adds it to the list of head components, resolving the issue.