### PR TITLE
Stop appending empty title tags

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,4 +1,13 @@
 "use strict";
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -8,19 +17,22 @@ var react_1 = __importDefault(require("react"));
 var react_helmet_async_1 = require("react-helmet-async");
 var context = {};
 var onRenderBody = function (_a) {
+    var _b;
     var setHeadComponents = _a.setHeadComponents, setHtmlAttributes = _a.setHtmlAttributes, setBodyAttributes = _a.setBodyAttributes;
     var helmet = context.helmet;
     if (helmet) {
-        setHeadComponents([
-            helmet.base.toComponent(),
-            helmet.title.toComponent(),
+        var baseComponent = helmet.base.toComponent();
+        var titleComponent = helmet.title.toComponent();
+        var components = [
             helmet.priority.toComponent(),
             helmet.meta.toComponent(),
             helmet.link.toComponent(),
             helmet.style.toComponent(),
             helmet.script.toComponent(),
             helmet.noscript.toComponent()
-        ]);
+        ];
+        setHeadComponents(((_b = titleComponent[0]) === null || _b === void 0 ? void 0 : _b.props.children)
+            ? __spreadArray([baseComponent, titleComponent], components, true) : __spreadArray([baseComponent], components, true));
         setHtmlAttributes(helmet.htmlAttributes.toComponent());
         setBodyAttributes(helmet.bodyAttributes.toComponent());
     }

--- a/src/gatsby-ssr.tsx
+++ b/src/gatsby-ssr.tsx
@@ -12,16 +12,23 @@ export const onRenderBody: GatsbySSR['onRenderBody'] = ({
     const { helmet } = context;
 
     if (helmet) {
-        setHeadComponents([
-            helmet.base.toComponent(),
-            helmet.title.toComponent(),
+        const baseComponent = helmet.base.toComponent();
+        const titleComponent = helmet.title.toComponent() as unknown as any[];
+        const components = [
             helmet.priority.toComponent(),
             helmet.meta.toComponent(),
             helmet.link.toComponent(),
             helmet.style.toComponent(),
             helmet.script.toComponent(),
             helmet.noscript.toComponent()
-        ]);
+        ];
+
+        setHeadComponents(
+            titleComponent[0]?.props.children
+                ? [baseComponent, titleComponent, ...components]
+                : [baseComponent, ...components]
+        );
+
         setHtmlAttributes(helmet.htmlAttributes.toComponent());
         setBodyAttributes(helmet.bodyAttributes.toComponent());
     }


### PR DESCRIPTION
## Description

With the introduction of [Gatsby head API](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/), users won't be able to migrate piecemeal because this plugin appends empty `<title>` tag to pages so that when you specify a `Head` export with a `<title>`, you end up with multiple title tags subsequently breaking Seo.

This change ensures that empty title tags aren't appended

`gatsby-plugin-react-helmet` also introduced a similar change in https://github.com/gatsbyjs/gatsby/pull/36303