### PR TITLE
separate context for different pages with pathname

### DIFF
--- a/src/gatsby-ssr.tsx
+++ b/src/gatsby-ssr.tsx
@@ -2,7 +2,7 @@ import { GatsbySSR, RenderBodyArgs, WrapRootElementNodeArgs } from 'gatsby';
 import React from 'react';
 import { HelmetProvider, HelmetServerState } from 'react-helmet-async';
 
-const context: { helmet?: HelmetServerState } = {};
+const context: {[pathname: string]: { helmet?: HelmetServerState }} = {};
 
 export const onRenderBody: GatsbySSR['onRenderBody'] = ({
     setHeadComponents,
@@ -35,7 +35,11 @@ export const onRenderBody: GatsbySSR['onRenderBody'] = ({
 };
 
 export const wrapRootElement: GatsbySSR['wrapRootElement'] = ({
+    pathname,
     element
-}: WrapRootElementNodeArgs): React.ReactElement => (
-    <HelmetProvider context={context}>{element}</HelmetProvider>
-);
+}: WrapRootElementNodeArgs): React.ReactElement => {
+    context[pathname] = {};
+    return (
+        <HelmetProvider context={context[pathname]}>{element}</HelmetProvider>
+    );
+}


### PR DESCRIPTION
fix issue #97.
 by separating contexts of each page on rendering root element in `gatsby-ssr`